### PR TITLE
Fix for issue #28 / #29 related to Mark as Junk vs. Stack All Items binding

### DIFF
--- a/BUI_Shared.xml
+++ b/BUI_Shared.xml
@@ -43,7 +43,7 @@
         <Control name="BUI_GamepadMenuEntryLabelSizedTemplate" virtual="true">
             <OnInitialized>
                 ZO_SharedGamepadEntry_OnInitialized(self)
-                ZO_SharedGamepadEntry_SetHeightFromLabel(self)
+                ZO_SharedGamepadEntry_SetHeightFromLabels(self)
             </OnInitialized>
         </Control>
 

--- a/Modules/Inventory/Inventory.lua
+++ b/Modules/Inventory/Inventory.lua
@@ -1516,15 +1516,15 @@ function BUI.Inventory.Class:InitializeKeybindStrip()
         {
             name = function()
 				if(BUI.Settings.Modules["Inventory"].enableJunk) then
-				if (self.selectedItemUniqueId ~= nil) then
-					local targetData = self.itemList:GetTargetData()
-					local bag, index = ZO_Inventory_GetBagAndIndex(targetData)
-					if (IsItemJunk(bag, index)) then
-						return GetString(SI_ITEM_ACTION_UNMARK_AS_JUNK)
+					if (self.selectedItemUniqueId ~= nil) then
+						local targetData = self.itemList:GetTargetData()
+						local bag, index = ZO_Inventory_GetBagAndIndex(targetData)
+						if (IsItemJunk(bag, index)) then
+							return GetString(SI_ITEM_ACTION_UNMARK_AS_JUNK)
+						end
 					end
-				end
-				
-				return GetString(SI_ITEM_ACTION_MARK_AS_JUNK)
+					
+					return GetString(SI_ITEM_ACTION_MARK_AS_JUNK)
 				end
 				
 				return GetString(SI_ITEM_ACTION_STACK_ALL)

--- a/Modules/Inventory/Inventory.lua
+++ b/Modules/Inventory/Inventory.lua
@@ -1515,6 +1515,7 @@ function BUI.Inventory.Class:InitializeKeybindStrip()
         --},
         {
             name = function()
+				if(BUI.Settings.Modules["Inventory"].enableJunk) then
 				if (self.selectedItemUniqueId ~= nil) then
 					local targetData = self.itemList:GetTargetData()
 					local bag, index = ZO_Inventory_GetBagAndIndex(targetData)
@@ -1524,6 +1525,9 @@ function BUI.Inventory.Class:InitializeKeybindStrip()
 				end
 				
 				return GetString(SI_ITEM_ACTION_MARK_AS_JUNK)
+				end
+				
+				return GetString(SI_ITEM_ACTION_STACK_ALL)
 			
 				--local selectedData = self.categoryList.selectedData
 				--return (selectedData.filterType == ITEMFILTERTYPE_JUNK) and GetString(SI_ITEM_ACTION_UNMARK_AS_JUNK) or 
@@ -1535,41 +1539,41 @@ function BUI.Inventory.Class:InitializeKeybindStrip()
             disabledDuringSceneHiding = true,
 
 			visible = function()
-				if (self.selectedItemUniqueId ~= nil) then
-				--*--if self.selectedItemUniqueId ~= nil then
-					local targetData = self.itemList:GetTargetData()
-					return IsInventorySlotLockedOrJunk(targetData)
-					--*--return ZO_InventorySlot_CanDestroyItem(targetData)
-				else
-                    local targetData = self.itemList:GetTargetData()
-                    if (targetData ~= nil) then
-                        return IsInventorySlotLockedOrJunk(targetData)
-					--*--return true
+				if(BUI.Settings.Modules["Inventory"].enableJunk) then
+					if (self.selectedItemUniqueId ~= nil) then
+					--*--if self.selectedItemUniqueId ~= nil then
+						local targetData = self.itemList:GetTargetData()
+						return IsInventorySlotLockedOrJunk(targetData)
+						--*--return ZO_InventorySlot_CanDestroyItem(targetData)
+					else
+						local targetData = self.itemList:GetTargetData()
+						if (targetData ~= nil) then
+							return IsInventorySlotLockedOrJunk(targetData)
+						--*--return true
+						end
 					end
+					
+					return false
 				end
-				----return (self.selectedItemUniqueId ~= nil)
-                --local targetData = self.itemList:GetTargetData()
-				--if (self.selectedItemUniqueId ~= nil) then 
-				--local bag, index = ZO_Inventory_GetBagAndIndex(targetData)
-				--return not IsItemJunk(bag, index)
-                --return self.selectedItemUniqueId ~= nil and ZO_InventorySlot_CanDestroyItem(targetData)
-				--end
-				return false
+				
+				return true
 			end,
 
             callback = function()
-				if (self.selectedItemUniqueId ~= nil) then
-                local targetData = self.itemList:GetTargetData()
-					local bag, index = ZO_Inventory_GetBagAndIndex(targetData)
-					local isJunk = not IsItemJunk(bag, index)
-					if (not IsItemPlayerLocked(bag, index) or (IsItemPlayerLocked(bag, index) and not isJunk)) then
-						SetItemIsJunk(bag, index, isJunk)
-						PlaySound(isJunk and SOUNDS.INVENTORY_ITEM_JUNKED or SOUNDS.INVENTORY_ITEM_UNJUNKED)
-                	--*--if(ZO_InventorySlot_CanDestroyItem(targetData) and ZO_InventorySlot_InitiateDestroyItem(targetData)) then
-                	--*--    self.itemList:Deactivate()
-                	--*--    self.listWaitingOnDestroyRequest = self.itemList
-                	end
-            	end
+				if(BUI.Settings.Modules["Inventory"].enableJunk) then
+					if (self.selectedItemUniqueId ~= nil) then
+					local targetData = self.itemList:GetTargetData()
+						local bag, index = ZO_Inventory_GetBagAndIndex(targetData)
+						local isJunk = not IsItemJunk(bag, index)
+						if (not IsItemPlayerLocked(bag, index) or (IsItemPlayerLocked(bag, index) and not isJunk)) then
+							SetItemIsJunk(bag, index, isJunk)
+							PlaySound(isJunk and SOUNDS.INVENTORY_ITEM_JUNKED or SOUNDS.INVENTORY_ITEM_UNJUNKED)
+						end
+					end
+				else
+					-- Stack All Items
+					StackBag(BAG_BACKPACK)
+				end
             end
         }
     }


### PR DESCRIPTION
This at least addresses the issue where "Mark as Junk" binding shows up regardless of the junk setting being disabled. It now honors this setting and if Inventory Junk setting is disabled it will display / use the "Stack All Items" as the "UI_SHORTCUT_RIGHT_STICK" binding. Issue #29 and #28 are pretty much the same issue -- with the exception that we may need to add an actions ("Y button") menu item to Stack All Items or similar.

Thanks!